### PR TITLE
Clear Dependabot high alert (google-protobuf)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'opentelemetry-sdk'
 gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 gem "rspec"
+gem "google-protobuf", ">= 3.25.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,14 @@
 PATH
   remote: .
   specs:
-    codecov_opentelem (0.1.5)
+    codecov_opentelem (0.1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.0)
-    google-protobuf (3.21.1-x86_64-darwin)
+    google-protobuf (3.25.8-aarch64-linux)
+    google-protobuf (3.25.8-x86_64-darwin)
     googleapis-common-protos-types (1.3.1)
       google-protobuf (~> 3.14)
     opentelemetry-api (1.0.2)
@@ -207,10 +208,12 @@ GEM
     ruby2_keywords (0.0.5)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-21
 
 DEPENDENCIES
   codecov_opentelem!
+  google-protobuf (>= 3.25.5)
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
   opentelemetry-sdk


### PR DESCRIPTION
## Summary
- Raise `google-protobuf` to >=3.25.5 to clear the open high Dependabot alert.

## Test plan
- [ ] Confirm Dependabot high clears after merge
- [ ] Run rspec in CI
